### PR TITLE
syskit: fix support for recursive models in SDF

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,0 +1,8 @@
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+    t.libs << "."
+    t.libs << "lib"
+    t.test_files = FileList['test/test_*.rb']
+    t.warning = false
+end

--- a/ruby/lib/transformer.rb
+++ b/ruby/lib/transformer.rb
@@ -712,12 +712,17 @@ module Transformer
             tr
         end
 
+        # @deprecated for backward compatibility only, renamed to {#has_transform?} for consistency with the rest of the API
+        def has_transformation?(from, to)
+            has_transform?(from, to)
+        end
+
         # Checks if a transformation between the provided frames exist.
         #
         # It will return true if such a transformation has been registered,
         # false otherwise, and raises ArgumentError if either +from+ or +to+ are
         # not registered frames.
-        def has_transformation?(from, to)
+        def has_transform?(from, to)
             result = transforms.has_key?([from, to])
 
             if !result
@@ -730,10 +735,15 @@ module Transformer
             result
         end
 
+        # @deprecated for backward compatibility only, renamed to {#transform_for} for consistency with the rest of the API
+        def transformation_for(from, to)
+            transform_for(from, to)
+        end
+
         # Returns the transformation object that represents the from -> to
         # transformation, if there is one. If none is found, raises
         # ArgumentError
-        def transformation_for(from, to)
+        def transform_for(from, to)
             result = transforms[[from, to]]
             if !result
                 if !has_frame?(from)

--- a/ruby/lib/transformer.rb
+++ b/ruby/lib/transformer.rb
@@ -536,12 +536,14 @@ module Transformer
 
             transforms = Hash.new
             @transforms.each do |(from, to), tr|
-                transforms[[tr.from, tr.to]] = tr.rename_frames(mapping).freeze
+                tr = tr.rename_frames(mapping).freeze
+                transforms[[tr.from, tr.to]] = tr
             end
 
             example_transforms = Hash.new
             @example_transforms.each do |(from, to), tr|
-                example_transforms[[tr.from, tr.to]] = tr.rename_frames(mapping).freeze
+                tr = tr.rename_frames(mapping).freeze
+                example_transforms[[tr.from, tr.to]] = tr
             end
 
             @frames = frames

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -40,12 +40,15 @@ module Transformer
 
         def parse_sdf_links_and_joints(sdf, prefix = "", parent_name = "", world_name: nil, &producer_resolver)
             root_links = Hash.new
-            sdf.each_link do |l|
-                root_links[l.name] = l
+            relative_link_names = Hash.new
+            sdf.each_link_with_name do |l, l_name|
+                root_links[l_name] = l
+                relative_link_names[l] = l_name
             end
 
             world_link = ::SDF::Link::World
-            sdf.each_joint do |j|
+
+            sdf.each_joint_with_name do |j|
                 parent = j.parent_link
                 child  = j.child_link
                 root_links.delete(child.name)
@@ -73,12 +76,12 @@ module Transformer
                 if world_name && (parent == world_link)
                     parent = world_name 
                 else
-                    parent = sdf_append_name(parent_name, parent.name)
+                    parent = sdf_append_name(parent_name, relative_link_names[parent])
                 end
                 if world_name && (child == world_link)
                     child = world_name
                 else
-                    child  = sdf_append_name(parent_name, child.name)
+                    child  = sdf_append_name(parent_name, relative_link_names[child])
                 end
 
                 if upper == lower

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -83,6 +83,7 @@ module Transformer
 
             relative_link_names = Hash.new
             sdf.each_link_with_name do |l, l_name|
+                frames sdf_append_name(prefix, l_name)
                 relative_link_names[l] = l_name
             end
 

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -4,7 +4,7 @@ module Transformer
     module SDF
         # Load a SDF model or file and convert it into a transformer configuration
         def load_sdf(model, exclude_models: [], &producer_resolver)
-            model = ::SDF::Root.load(model)
+            model = ::SDF::Root.load(model, flatten: false)
             parse_sdf_root(model, exclude_models: exclude_models, &producer_resolver)
         end
 

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -56,6 +56,14 @@ module Transformer
             end
             pose
         end
+        def sdf_link_pose_in_model(m, sdf)
+            pose = Eigen::Isometry3.Identity
+            while m!=sdf
+                pose = m.pose * pose
+                m = m.parent
+            end
+            pose
+        end
 
         def parse_sdf_links_and_joints(sdf, prefix = "", parent_name = "", world_name: nil, &producer_resolver)
             submodel2model = Hash.new
@@ -81,7 +89,7 @@ module Transformer
             world_link = ::SDF::Link::World
 
             if root_link = sdf.each_link.first
-                static_transform(*root_link.pose, sdf_append_name(prefix, relative_link_names[root_link]) => parent_name)
+                static_transform(*sdf_link_pose_in_model(root_link,sdf), sdf_append_name(prefix, relative_link_names[root_link]) => parent_name)
             end
 
             sdf.each_joint_with_name do |j, j_name|

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -70,8 +70,9 @@ module Transformer
                         joint2model = child2model * joint2child
                         axis = joint2model.rotation.inverse * axis
                     end
-                    post2pre = j.transform_for((upper + lower) / 2, axis)
+                    post2pre = j.transform_for((upper + lower) / 2, nil, axis)
                 end
+
                 # Handle the special 'world' link
                 if world_name && (parent == world_link)
                     parent = world_name 

--- a/ruby/lib/transformer/syskit/extensions/instance_requirements.rb
+++ b/ruby/lib/transformer/syskit/extensions/instance_requirements.rb
@@ -86,6 +86,11 @@ module Transformer
                 end
             end
         end
+
+        # Resolves the transform associated with a port
+        def find_transform_of_port(port)
+            model.find_transform_of_port(port.attach(model))
+        end
     end
 end
 

--- a/ruby/lib/transformer/test.rb
+++ b/ruby/lib/transformer/test.rb
@@ -45,6 +45,12 @@ module Transformer
             super
             # Teardown code for all the tests
         end
+
+        def assert_eigen_approx(expected, actual, msg = nil)
+            if !expected.approx?(actual)
+                flunk(msg || "expected #{actual} to be approximately equal to #{expected}")
+            end
+        end
     end
 end
 

--- a/ruby/test/data/sdf/joint_with_use_parent_model_frame/model.config
+++ b/ruby/test/data/sdf/joint_with_use_parent_model_frame/model.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<model>
+  <sdf>model.sdf</sdf>
+</model>
+

--- a/ruby/test/data/sdf/joint_with_use_parent_model_frame/model.sdf
+++ b/ruby/test/data/sdf/joint_with_use_parent_model_frame/model.sdf
@@ -4,16 +4,16 @@
     <world name="w">
         <model name="m">
             <link name="root_link">
-                <pose>1 2 3 90 0 0</pose>
+                <pose>1 2 3 0 0 0</pose>
             </link>
             <link name="child_link">
-                <pose>1 2 3 90 0 0</pose>
+                <pose>1 2 3 0 0 1.5708</pose>
             </link>
             <joint name='j' type='revolute'>
-                <pose>1 2 3 0 0 2</pose>
                 <parent>root_link</parent>
                 <child>child_link</child>
                 <axis>
+                    <use_parent_model_frame>true</use_parent_model_frame>
                     <xyz>1 0 0</xyz>
                     <limit>
                         <upper>0.2</upper>

--- a/ruby/test/data/sdf/joint_with_world_link/model.config
+++ b/ruby/test/data/sdf/joint_with_world_link/model.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<model>
+  <sdf>model.sdf</sdf>
+</model>
+

--- a/ruby/test/data/sdf/joint_with_world_link/model.sdf
+++ b/ruby/test/data/sdf/joint_with_world_link/model.sdf
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+
+<sdf>
+    <world name="w">
+        <model name="root">
+            <link name="l" />
+            <link name="parent_of_world" />
+            <link name="child_of_world" />
+
+            <model name="submodel">
+                <link name="l" />
+            </model>
+
+            <joint name="joint_with_world_as_child" type="fixed">
+                <parent>parent_of_world</parent>
+                <child>world</child>
+            </joint>
+            <joint name="joint_with_world_as_parent" type="fixed">
+                <parent>world</parent>
+                <child>child_of_world</child>
+            </joint>
+            <joint name="attach_submodel_to_parent" type="fixed">
+                <parent>submodel::l</parent>
+                <child>l</child>
+            </joint>
+        </model>
+    </world>
+</sdf>
+

--- a/ruby/test/data/sdf/model_with_only_root_links/model.sdf
+++ b/ruby/test/data/sdf/model_with_only_root_links/model.sdf
@@ -3,9 +3,9 @@
 <sdf>
     <world name="w">
         <model name="m">
-            <pose>0 1 2 0 0 1</pose>
+            <pose>0 1 2 0 0 0</pose>
             <link name="root_link">
-                <pose>1 2 3 0 0 2</pose>
+                <pose>1 2 3 0 0 1</pose>
             </link>
         </model>
     </world>

--- a/ruby/test/data/sdf/static_model/model.config
+++ b/ruby/test/data/sdf/static_model/model.config
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+
+<model>
+  <sdf>model.sdf</sdf>
+</model>
+

--- a/ruby/test/data/sdf/static_model/model.sdf
+++ b/ruby/test/data/sdf/static_model/model.sdf
@@ -4,9 +4,7 @@
     <world name="w">
         <model name="m">
             <pose>0 1 2 0 0 1</pose>
-            <link name="root_link">
-                <pose>1 2 3 0 0 2</pose>
-            </link>
+            <static>true</static>
         </model>
     </world>
 </sdf>

--- a/ruby/test/data/sdf/static_model/model.sdf
+++ b/ruby/test/data/sdf/static_model/model.sdf
@@ -3,8 +3,11 @@
 <sdf>
     <world name="w">
         <model name="m">
-            <pose>0 1 2 0 0 1</pose>
+            <pose>0 1 2 0 0 0</pose>
             <static>true</static>
+            <link name="root_link">
+                <pose>1 2 3 0 0 1</pose>
+            </link>
         </model>
     </world>
 </sdf>

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -186,6 +186,40 @@ module Transformer
                 t = conf.transformation_for('m::subm::l', 'm::l')
                 assert_equal Eigen::Vector3.new(5, 7, 9), t.translation
             end
+            it "applies the pose of the submodels recursively" do
+                load_sdf(<<-EOSDF)
+                <sdf><world name="w">
+                <model name="m">
+                   <pose>1 2 3 0 0 0</pose>
+                   <model name="subm">
+                      <pose>2 3 4 0 0 0</pose>
+                      <model name="subm2">
+                         <link name="l">
+                           <pose>3 4 5 0 0 0</pose>
+                         </link>
+                      </model>
+                   </model>
+                </model></world></sdf>
+                EOSDF
+               t = conf.transformation_for('m::subm::subm2::l', 'm')
+               assert_eigen_approx Eigen::Vector3.new(5, 7, 9), t.translation
+            end
+            it "applies the pose of the first link, even when there is no link on the parent model" do
+                load_sdf(<<-EOSDF)
+                <sdf><world name="w">
+                <model name="m">
+                   <pose>1 2 3 0 0 0</pose>
+                   <model name="subm">
+                      <pose>2 3 4 0 0 0</pose>
+                      <link name="l">
+                        <pose>3 4 5 0 0 0</pose>
+                      </link>
+                   </model>
+                </model></world></sdf>
+                EOSDF
+                t = conf.transformation_for('m::subm::l', 'm')
+                assert_equal Eigen::Vector3.new(5, 7, 9), t.translation
+            end
         end
 
         def load_sdf(sdf_xml)

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -61,6 +61,20 @@ module Transformer
             tr = conf.example_transformation_for('m::j_post', 'm::j_pre')
             assert_equal Eigen::Vector3.Zero, tr.translation
             assert Eigen::Quaternion.from_angle_axis(1.5, Eigen::Vector3.UnitX).approx?(tr.rotation)
+        describe "handling of the special 'world' link" do
+            it "creates a transform between the world frame and another link in case a joint has 'world' as parent" do
+                conf.load_sdf('model://joint_with_world_link')
+                t = conf.transformation_for 'w', 'root::parent_of_world'
+                assert_equal Eigen::Vector3.Zero, t.translation
+                assert_equal Eigen::Quaternion.Identity, t.rotation
+            end
+            it "creates a transform between the world frame and another link in case a joint has 'world' as child" do
+                conf.load_sdf('model://joint_with_world_link')
+                t = conf.transformation_for 'root::child_of_world', 'w'
+                assert_equal Eigen::Vector3.Zero, t.translation
+                assert_equal Eigen::Quaternion.Identity, t.rotation
+            end
+        end
         end
     end
 end

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -70,6 +70,21 @@ module Transformer
             assert 'producer', tr.producer
         end
 
+        it "declares even frames that are not linked to the root frame through joints" do
+            load_sdf(<<-EOSDF)
+            <sdf><world name="w">
+            <model name="m"><link name="root" />
+              <link name="l" />
+              <model name="subm"><link name="l" />
+                <model name="subsubm"><link name="l" />
+                </model>
+              </model>
+            </model></world></sdf>
+            EOSDF
+            assert conf.has_frame?('m::l')
+            assert conf.has_frame?('m::subm::l')
+            assert conf.has_frame?('m::subm::subsubm::l')
+        end
 
         describe "example transform for revolute joints" do
             it "provides an example transform that matches the middle of the axis range " do

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -75,6 +75,18 @@ module Transformer
                 assert_equal Eigen::Quaternion.Identity, t.rotation
             end
         end
+
+        describe "handling of models in models" do
+            it "creates properly namespaced frames" do
+                conf.load_sdf('model://joint_with_world_link')
+                assert conf.has_frame?('root::submodel::l')
+            end
+            it "handles namespaces properly when creating cross-model joints" do
+                conf.load_sdf('model://joint_with_world_link')
+                t = conf.transformation_for('root::l', 'root::submodel::l')
+                assert_equal 'root::l', t.from
+                assert_equal 'root::submodel::l', t.to
+            end
         end
     end
 end

--- a/ruby/test/test_transformer.rb
+++ b/ruby/test/test_transformer.rb
@@ -1,5 +1,100 @@
 require 'transformer/test'
 
+module Transformer
+    describe Configuration do
+        before do
+            @manager = Configuration.new
+        end
+
+        describe "#rename_frames" do
+            describe "frame set" do
+                it "applies the renames to the frame set" do
+                    @manager.frames 'to_rename'
+                    @manager.rename_frames 'to_rename' => 'test'
+                    assert_equal ['test'], @manager.frames.to_a
+                end
+                it "does not modify frames that are not specified" do
+                    @manager.frames 'to_rename'
+                    @manager.rename_frames Hash.new
+                    assert_equal ['to_rename'], @manager.frames.to_a
+                end
+            end
+
+            describe "static transforms" do
+                before do
+                    @t = Eigen::Vector3.new(1, 2, 3)
+                    @q = Eigen::Quaternion.new(1, 2, 3, 4)
+                    @manager.static_transform @t, @q, 'to_rename_src' => 'to_rename_dst'
+                end
+
+                it "applies the renames to the static transforms" do
+                    @manager.rename_frames 'to_rename_src' => 'src', 'to_rename_dst' => 'dst'
+                    transform = @manager.transformation_for 'src', 'dst'
+                    assert_equal 'src', transform.from
+                    assert_equal 'dst', transform.to
+                    assert_equal @t, transform.translation
+                    assert_equal @q, transform.rotation
+                end
+                it "does not modify frames that are not specified" do
+                    @manager.rename_frames Hash.new
+                    transform = @manager.transformation_for 'to_rename_src', 'to_rename_dst'
+                    assert_equal 'to_rename_src', transform.from
+                    assert_equal 'to_rename_dst', transform.to
+                    assert_equal @t, transform.translation
+                    assert_equal @q, transform.rotation
+                end
+            end
+
+            describe "dynamic transforms" do
+                before do
+                    @producer = flexmock
+                    @producer.should_receive(dup: @producer)
+                    @manager.dynamic_transform @producer, 'to_rename_src' => 'to_rename_dst'
+                end
+                it "applies the renames to the dynamic transforms" do
+                    @manager.rename_frames 'to_rename_src' => 'src', 'to_rename_dst' => 'dst'
+                    transform = @manager.transformation_for 'src', 'dst'
+                    assert_equal 'src', transform.from
+                    assert_equal 'dst', transform.to
+                    assert_equal @producer, transform.producer
+                end
+                it "does not modify frames that are not specified" do
+                    @manager.rename_frames Hash.new
+                    transform = @manager.transformation_for 'to_rename_src', 'to_rename_dst'
+                    assert_equal 'to_rename_src', transform.from
+                    assert_equal 'to_rename_dst', transform.to
+                    assert_equal @producer, transform.producer
+                end
+            end
+
+            describe "example transforms" do
+                before do
+                    @t = Eigen::Vector3.new(1, 2, 3)
+                    @q = Eigen::Quaternion.new(1, 2, 3, 4)
+                    @manager.example_transform @t, @q, 'to_rename_src' => 'to_rename_dst'
+                end
+                it "applies the renames to the example transforms" do
+                    @manager.rename_frames 'to_rename_src' => 'src', 'to_rename_dst' => 'dst'
+                    transform = @manager.example_transform_for 'src', 'dst'
+                    assert_equal 'src', transform.from
+                    assert_equal 'dst', transform.to
+                    assert_equal @t, transform.translation
+                    assert_equal @q, transform.rotation
+                end
+                it "does not modify frames that are not specified" do
+                    @manager.rename_frames Hash.new
+                    transform = @manager.example_transform_for 'to_rename_src', 'to_rename_dst'
+                    assert_equal 'to_rename_src', transform.from
+                    assert_equal 'to_rename_dst', transform.to
+                    assert_equal @t, transform.translation
+                    assert_equal @q, transform.rotation
+                end
+            end
+        end
+    end
+end
+
+
 class TC_Transformer < Minitest::Test
     attr_reader :trsf, :transforms
     def conf; trsf.conf end

--- a/ruby/test/test_transformer.rb
+++ b/ruby/test/test_transformer.rb
@@ -142,14 +142,5 @@ class TC_Transformer < Minitest::Test
         assert_equal 2, copy.transforms.size
         assert_equal 3, copy.frames.size
     end
-
-    def test_dup_isolates_the_static_transformations_of_the_receiver_from_the_new_object
-        trsf = Transformer::TransformationManager.new
-        conf = trsf.conf
-        conf.static_transform Eigen::Vector3.new(0, 0, 0), "body" => "servo_low"
-        copy = conf.dup
-        conf.transforms.first[1].translation.x = 10
-        assert_equal 0, copy.transforms.first[1].translation.x
-    end
 end
 


### PR DESCRIPTION
This supports

~~~
<model ...>
   <model ...>
   </model>
</model>
~~~

where the inner model is not flattened. Moreover, it supports the 'world' link in joints, which is used to attach a link in the world (i.e. make it static).