### PR TITLE
syskit: do not attempt to load the transformer task library in SyskitPlugin.enable

### DIFF
--- a/ruby/lib/transformer/syskit/plugin.rb
+++ b/ruby/lib/transformer/syskit/plugin.rb
@@ -292,7 +292,6 @@ module Transformer
 
         def self.enable
             Roby.app.add_plugin 'syskit-transformer', RobyAppPlugin
-            Roby.app.using_task_library "transformer"
 
             # Maintain a transformer broadcaster on the main engine
             Roby::ExecutionEngine.add_propagation_handler(description: 'syskit-transformer transformer broadcaster start') do |plan|

--- a/ruby/test/syskit/test_syskit_plugin.rb
+++ b/ruby/test/syskit/test_syskit_plugin.rb
@@ -6,6 +6,7 @@ describe Transformer::SyskitPlugin do
     before do
         Roby.app.import_types_from 'base'
         Roby.app.import_types_from 'transformer'
+        Roby.app.using_task_library 'transformer'
         Syskit.conf.transformer_warn_about_unset_frames = false
 
         @transform_producer_m = Syskit::TaskContext.new_submodel name: 'TransformProducer' do


### PR DESCRIPTION
This is at a place where the common_models bundle is not necessarily
available. The plugin already loads the plugin in require_models (the
right place).

This was added to get the test suite to pass when files were
executed one by one. Just add using_task_library there.