### PR TITLE
syskit: do not define 'configure' at all on versions of Syskit that support update_properties

### DIFF
--- a/ruby/lib/transformer/syskit/extensions/task_context.rb
+++ b/ruby/lib/transformer/syskit/extensions/task_context.rb
@@ -190,11 +190,11 @@ module Transformer
             end
         end
 
-        def configure
-            super
-
-            # Backward compatibility with older Syskit versions
-            update_properties unless model.respond_to?(:use_update_properties?)
+        unless Syskit::TaskContext.respond_to?(:use_update_properties?)
+            def configure
+                super
+                update_properties
+            end
         end
     end
 


### PR DESCRIPTION
It otherwise triggers the "you defined configure but are not
defining update_properties" check.