### PR TITLE
fix: issues with submodels (on top of #17)

### DIFF
--- a/ruby/lib/transformer.rb
+++ b/ruby/lib/transformer.rb
@@ -862,6 +862,26 @@ module Transformer
             joints.each(&block)
         end
 
+        # Resolve a static transformation between the two given frames
+        #
+        # @return [Eigen::Isometry3]
+        # @raise [TransformationNotFound]
+        # @see try_resolve_static_chain
+        def resolve_static_chain(from_frame, to_frame)
+            TransformationManager.new(self).resolve_static_chain(from_frame, to_frame)
+        end
+
+        # Try resolving a static transformation between the two given frames
+        #
+        # Unlike {#resolve_static_chain}, return nil if a chain cannot be found
+        #
+        # @return [Eigen::Isometry3,nil]
+        # @see try_resolve_static_chain
+        def try_resolve_static_chain(from_frame, to_frame)
+            resolve_static_chain(from_frame, to_frame)
+        rescue TransformationNotFound # rubocop:disable Lint/SuppressedException
+        end
+
         def pretty_print(pp)
             pp.text "Transformer configuration"
             pp.nest(2) do

--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -94,6 +94,17 @@ module Transformer
             pose
         end
 
+        # Define frames for a model and its canonical link
+        def sdf_add_root_model(sdf, prefix = "")
+            return unless (canonical_link = sdf.canonical_link)
+
+            static_transform(
+                Eigen::Vector3.Zero,
+                sdf_append_name(prefix, "#{sdf.name}::#{canonical_link.name}") =>
+                    sdf_append_name(prefix, sdf.name)
+            )
+        end
+
         # @api private
         #
         # Define frames for links, and either static, dynamic or example transformations

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -84,6 +84,31 @@ module Transformer
             assert conf.has_frame?('m::subm::subsubm::l')
         end
 
+        describe "#sdf_add_root_model" do
+            it "declares the frame of the root model" do
+                load_sdf(<<-EOSDF)
+                <sdf><world name="w"><model name="m" /></world></sdf>
+                EOSDF
+
+                assert conf.frame?("m")
+            end
+
+            it "declares the static transform between the root model and its " \
+               "canonical link" do
+                load_sdf(<<-EOSDF)
+                <sdf><world name="w">
+                    <model name="m">
+                        <link name="canonical" />
+                    </model>
+                </world></sdf>
+                EOSDF
+
+                assert conf.frame?("m::canonical")
+                assert_equal Eigen::Isometry3.Identity,
+                             conf.resolve_static_chain("m", "m::canonical")
+            end
+        end
+
         describe "example transform for revolute joints" do
             it "provides an example transform that matches the middle of the axis range " do
                 conf.load_sdf('model://model_with_child_links')

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -205,7 +205,19 @@ module Transformer
         describe "handling of models in models" do
             it "creates properly namespaced frames" do
                 conf.load_sdf('model://joint_with_world_link')
-                assert conf.has_frame?('root::submodel::l')
+                assert conf.frame?('root::submodel::l')
+            end
+            it "defines a frame for the submodel" do
+                conf.load_sdf('model://joint_with_world_link')
+                assert conf.frame?('root::submodel')
+            end
+            it "connects the submodel's frame to its canonical link" do
+                conf.load_sdf("model://joint_with_world_link")
+                assert_equal(
+                    Eigen::Isometry3.Identity,
+                    conf.transform_for("root::submodel::l", "root::submodel")
+                        .to_isometry
+                )
             end
             it "handles namespaces properly when creating cross-model joints" do
                 conf.load_sdf('model://joint_with_world_link')


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-control/control-ruby_sdformat/pull/36

On top of #17

The main fix is with the lack of a frame that represents the model, and making sure that this frame points to the model's first link ("canonical link"). The two other commits that are related because they are used in rock-gazebo to fix other issues with submodels.